### PR TITLE
Feature/successor urn

### DIFF
--- a/R/gias.R
+++ b/R/gias.R
@@ -7,4 +7,4 @@ gias <- read.csv(paste0("http://ea-edubase-api-prod.azurewebsites.net/edubase/ed
     open_date = as.Date(open_date, format = "%d-%m-%Y"),
     close_date = as.Date(close_date, format = "%d-%m-%Y")
   ) %>%
-  select(urn, open_date, close_date)
+  select(urn, open_date, close_date, type_of_establishment_name)

--- a/R/gias.R
+++ b/R/gias.R
@@ -1,0 +1,10 @@
+library(dplyr)
+library(janitor)
+
+gias <- read.csv(paste0("http://ea-edubase-api-prod.azurewebsites.net/edubase/edubasealldata",gsub("-","",Sys.Date()),".csv")) %>%
+  clean_names() %>%
+  mutate(
+    open_date = as.Date(open_date, format = "%d-%m-%Y"),
+    close_date = as.Date(close_date, format = "%d-%m-%Y")
+  ) %>%
+  select(urn, open_date, close_date)

--- a/R/gias_predecessors.R
+++ b/R/gias_predecessors.R
@@ -1,0 +1,76 @@
+library(dplyr)
+library(janitor)
+
+links <- read.csv(paste0("http://ea-edubase-api-prod.azurewebsites.net/edubase/links_edubasealldata",gsub("-","",Sys.Date()),".csv"))
+
+successor_links <- links %>%
+  filter(grepl("Suc", LinkType)) %>%
+  select(URN, LinkURN, LinkType)
+
+predecessor <- successor_links %>%
+  # Drop circular links
+  filter(!(URN %in% c(122057, 122060, 135073, 147355))) %>%
+  # Add flag for Merge
+  group_by(LinkURN) %>%
+  mutate(n_lurn = n()) %>%
+  ungroup() %>%
+  mutate(
+  MergeFlag = ifelse(n_lurn > 1, 1, 0),
+  LinkType
+  ) %>% 
+  # Add flag for split
+  group_by(URN) %>%
+  mutate(n_urn = n()) %>%
+  ungroup() %>%
+  mutate(
+    SplitFlag = ifelse(n_urn > 1, 1,0),
+    LinkType = "Predecessor",
+    Level = 1
+  ) %>%
+  # Remove any splits or mergers
+  filter(
+    SplitFlag == 0, 
+    MergeFlag == 0
+  ) %>%
+  select(
+  URN = LinkURN,
+  LinkURN = URN,
+  LinkType,
+  Level
+  )
+
+predecessors <- predecessor
+
+rows <- TRUE
+
+while (rows == TRUE) {
+  
+  predecessor_next_level <- predecessors %>%
+    filter(Level == max(Level, na.rm = TRUE)) %>%
+    select(URN, LinkURN, Level) %>%
+    left_join(select(predecessor, URN, LinkURN), by = c("LinkURN" = "URN")) %>%
+    filter(!is.na(LinkURN.y)) %>% 
+    filter(LinkURN != LinkURN.y) %>% 
+    mutate(
+      Level = max(Level, na.rm = TRUE) + 1,
+      LinkType = "Predecessor"
+    ) %>%
+    select(-LinkURN) %>% 
+    rename(LinkURN = LinkURN.y)
+  
+  predecessors <- bind_rows(predecessors, predecessor_next_level)
+  
+  rows <- nrow(predecessor_next_level) > 0 
+
+}
+
+# Remove any urns duplicated in history
+predecessors <- predecessors %>% 
+  group_by(URN, LinkURN) %>%
+  filter(Level == min(Level, na.rm = TRUE)) %>%
+  ungroup() 
+
+n_predecessor <- predecessor %>%
+  group_by(URN) %>%
+  count() %>%
+  ungroup()

--- a/R/gias_predecessors.R
+++ b/R/gias_predecessors.R
@@ -68,9 +68,4 @@ while (rows == TRUE) {
 predecessors <- predecessors %>% 
   group_by(URN, LinkURN) %>%
   filter(Level == min(Level, na.rm = TRUE)) %>%
-  ungroup() 
-
-n_predecessor <- predecessor %>%
-  group_by(URN) %>%
-  count() %>%
   ungroup()

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ Running the run.R will do the following:
 2. Download all of the files to a temporary directory
 3. Read in and clean the datasets based on a predefined set of naming conventions (names have changed over time).
 4. Stack all of the datasets together
-5. Subset the dataset so that we have one line per URN and Inspection ID.
-6. Output the clean dataset ofsted_all.csv to the outputs folder
+5. Utilise Gias all data extract to identify inspection urn for all inspections.
+6. Utilise Gias links to calculate all successor schools that inspections should be marked against.
+7. Impute rows for successor urns such that an inspection id has a row for inspection urn and successor urns (marked which was the inspection urn on each row.).
+8. Append any left overs not capture by methedology but in original dataset.
+9. Output the clean dataset ofsted_all.csv to the outputs folder
 
 If there are no changes to the naming conventions for fields used in the files then running this script will work over time. If there are changes it will fail and the names should be added to the code for recoding.
 

--- a/run.R
+++ b/run.R
@@ -305,14 +305,14 @@ all_data <- monthly_clean_dataset %>%
 
 # Modify data to map to all successor schools -----------------------------
 
-# Add flag for if inspection is for urn based on number of predecessors
-all_data_inspection_urn_flag <- all_data %>%
-  left_join(n_predecessor, by = c("urn" = "URN")) %>%
-  mutate(n = ifelse(is.na(n), 0, n)) %>%
+# Add flag for inspection urn based on earliest closed date
+all_data_inspection_urn_flag <- all_data %>% 
+  left_join(gias, by = c("urn")) %>%
   group_by(inspection_id) %>%
   mutate(
-    inspection_urn_flag = ifelse(rank(n, ties.method = "first") == 1, 1, 0)
-  ) 
+    inspection_urn_flag = rank(close_date, ties.method = "average")
+  ) %>%
+  ungroup()
 
 # Mark the inspection urn of all inspections
 all_data_inspection_urn_all <- all_data_inspection_urn_flag %>%

--- a/run.R
+++ b/run.R
@@ -14,6 +14,7 @@ library(lubridate)
 
 # Source the gias predecessors code ---------------------------------------
 source("R/gias_predecessors.R")
+source("R/gias.R")
 
 # Create temp directory ---------------------------------------------------
 
@@ -349,7 +350,7 @@ all_data_non_inspection_urn_only <- predecessor %>%
   select(URN, LinkURN) %>%
   left_join(all_data_inspection_urn_only, by = c("LinkURN" = "urn")) %>%
   filter(!is.na(inspection_id)) %>% 
-  rename(urn = URN, inspection_urn = LinkURN)
+  rename(urn = URN)
 
 # Bind togehter to make the "calculated dataset"
 ofsted_all_calculated_successors <- bind_rows(

--- a/run.R
+++ b/run.R
@@ -346,7 +346,7 @@ all_data_inspection_urn_only <- all_data_inspection_urn_all %>%
   filter(urn == inspection_urn)
 
 # Create dataset of inspections for all successors
-all_data_non_inspection_urn_only <- predecessor %>%
+all_data_non_inspection_urn_only <- predecessors %>%
   select(URN, LinkURN) %>%
   left_join(all_data_inspection_urn_only, by = c("LinkURN" = "urn")) %>%
   filter(!is.na(inspection_id)) %>% 
@@ -373,6 +373,7 @@ all_data_final <- bind_rows(
 )
 
 write.csv(all_data_final, "outputs/ofsted_all.csv", row.names = FALSE, na = "")
+
 
 # Set git tags for release ---------------------------------------------------
 


### PR DESCRIPTION
This pull request makes the following changes:

1. Utilise Gias all data extract to identify inspection urn for all inspections.
2. Utilise Gias links to calculate all successor schools that inspections should be marked against.
3. Impute rows for successor urns such that an inspection id has a row for inspection urn and successor urns (marked which was the inspection urn on each row.)
4. Append any left overs not capture by methedology but in original dataset
