### PR TITLE
Bug/proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ r:
   
 sudo: required
 
-branches:
-  only:
-  - master
-
 cache:
   directories:
   - $HOME/.local/share/renv
@@ -25,3 +21,5 @@ deploy:
   file_glob: true
   file: outputs/*
   skip_cleanup: true
+  on: 
+    branch: master

--- a/R/ofsted_urn_linking.R
+++ b/R/ofsted_urn_linking.R
@@ -35,7 +35,10 @@ successor_link <- links %>%
   distinct(urn, link_urn, .keep_all = TRUE)
 
 # Read in a gias all data cut and select clean cols required
-gias <- read.csv(paste0("https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/edubasealldata",gsub("-","",Sys.Date()),".csv")) %>%
+
+gias_address <- paste0("https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/edubasealldata",gsub("-","",Sys.Date()),".csv")
+
+gias <- read.csv(url(gias_address, method = "libcurl")) %>%
   clean_names() %>%
   transmute(urn = as.integer(urn),
             establishment_name,

--- a/R/ofsted_urn_linking.R
+++ b/R/ofsted_urn_linking.R
@@ -6,7 +6,10 @@ library(tidylog)
 # Data preparation --------------------------------------------------------
 
 # Download the link files from gias and get clean cols required
-links <- read.csv(paste0("https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/links_edubasealldata",gsub("-","",Sys.Date()),".csv"), stringsAsFactors = FALSE) %>% 
+
+gias_links_address <- paste0("https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/links_edubasealldata",gsub("-","",Sys.Date()),".csv")
+
+links <- read.csv(url(gias_links_address, method = "libcurl"), stringsAsFactors = FALSE) %>% 
   clean_names() %>% 
   mutate(urn = as.integer(urn),
          link_urn = as.integer(link_urn),

--- a/run.R
+++ b/run.R
@@ -52,7 +52,7 @@ historical_file <- "https://assets.publishing.service.gov.uk/government/uploads/
 # Create function that downloads file with base file name to data folder
 download_w_file_name <- function(url, folder){
   
-  download.file(url, mode="wb", destfile = file.path(folder, basename(url)))
+  download.file(url, mode="wb", method = "libcurl", destfile = file.path(folder, basename(url)))
   
 }
 


### PR DESCRIPTION
## Background

With recent proxy changes in dfe i think there will be some problems running this locally now. There are for me at least when combined with using the latest proxy here: https://dfe-analytical-services.github.io/dfeR/

For things like read csv and download file we can now sometimes have problems if we just do say read.csv("the web address"). Instead we need to sometimes wrap the web address in the url function and specify that it should download the file using the libcurl method. E.g. read.csv(url("the web address", method = "libcurl").

This PR changes the code to use this so that it works with the proxy. 

## Steps taken

Set the download method for read_csv and download.file. Also brought the web address out to variables so that its a bit nicer to read.

## To do

If this builds on travis then all good. Would be good though @pchapman267 if you can just check it all runs locally for you now?